### PR TITLE
McCrea's attempts at debugging

### DIFF
--- a/R/.gitignore
+++ b/R/.gitignore
@@ -1,0 +1,2 @@
+http_helpers.R
+functions.RData

--- a/R/get_occ.R
+++ b/R/get_occ.R
@@ -169,11 +169,11 @@ get_AntWeb <- function(lat_range, lon_range, timeout) {
   # that can query AntWeb with geometry, but it tosses any links to documenting images
   # This function borrows (steals) heavily from that function but saves the links
   bbox <- paste(c(lat_range[2], lon_range[2], lat_range[1], lon_range[1]), collapse = ",")
-  base_url <- "http://www.antweb.org/api/v2/"
+  base_url <- "https://www.antweb.org/api/v3.1/specimens"
   try_GET <- try_verb_n(httr::GET)
   res <- try_GET(base_url, query = list(bbox = bbox, limit = 2000),
                  httr::timeout(timeout))
-  res <- jsonlite::fromJSON(httr::content(res, "text", encoding = "UTF-8"), FALSE)
+  res <- jsonlite::fromJSON(httr::content(res, "text", encoding = "UTF-8"), FALSE)  # problem lies here...
 
   if (res$count == 0) return(NULL)
   if (res$count > 2000) message("Only first 2000 matching AntWeb records returned.")

--- a/R/http_helpers.R
+++ b/R/http_helpers.R
@@ -34,7 +34,7 @@ gbif_count <- function(prop, ...) {
   n <- rgbif::occ_search(limit = 0, ...,
                          geometry = get_wkt(prop),
                          return = "meta")
-  pull(n, count)
+  n$meta$count
 }
 
 bison_count <- function(prop) {

--- a/R/manage_gets.R
+++ b/R/manage_gets.R
@@ -55,7 +55,7 @@ manage_gets <- function(prop, timeout) {
   if (!is.null(vn_recs))
     vn_recs <- clean_VertNet(vn_recs)
 
-  ## Berkeley 'Ecoinformatics' Eengine
+  ## Berkeley 'Ecoinformatics' Engine
   ee_recs <- get_EcoEngine(lat_range, lon_range, timeout)
   if (!is.null(ee_recs))
     ee_recs <- clean_EcoEngine(ee_recs)


### PR DESCRIPTION
Updates the clean_GBIF function to address error in vapply. Changes class to character.

Updates the standardize_occ function. Address mismatch between classes for sci_name values.

get_BISON: I was running into timeout issues using the estimated value for the `timeout` argument. Things worked when I increased `timeout` from 210 to 800.

get_VertNet returns NULL values randomly. It sounds like this is a known issue with their API, for whatever reason. I updated the month class to integer to align with `standardize_occ`. I added a few lines of QC to remove month values that made no sense (e.g., 88 or 0). 

clean_EcoEngine. Changes the class for loc_unc_m to double to align with `standardize_occ`. Adds `year`, `month`, and `day` values based on dates in the `begin_date` field.

get_AntWeb: updates the API address for v3.1. The link appears to be correct now, but it returns no information. I'd like to chat with you about this. 


